### PR TITLE
Complete theme support implementation

### DIFF
--- a/tha-theme-hooks.php
+++ b/tha-theme-hooks.php
@@ -21,7 +21,7 @@
 /**
  * Define the version of THA support, in case that becomes useful down the road.
  */
-define( 'THA_HOOKS_VERSION', '1.0-draft')
+define( 'THA_HOOKS_VERSION', '1.0-draft' );
 
 /** 
  * Themes and Plugins can check for tha_hooks using current_theme_supports( 'tha_hooks', $hook ) to determine 


### PR DESCRIPTION
With the current setup, THA works like Post Formats, where every supported format has to be explicitly registered. Reason: Even if only one hook type is registered with `add_theme_support( 'tha_hooks', array( 'head' ) )`, `current_theme_supports( 'tha_hooks' )` will  return true.

This patch reflects that, also moves the `core` flag to the registration array and fixes `current_theme_supports()` return value, when a second parameter is specified.
