### PR TITLE
Hook into wp_head() and wp_footer()

### DIFF
--- a/tha-theme-hooks.php
+++ b/tha-theme-hooks.php
@@ -101,20 +101,22 @@ add_filter( 'current_theme_supports-tha_hooks', 'tha_current_theme_supports', 10
  * Special case, useful for <DOCTYPE>, etc.
  * $tha_supports[] = 'html;
  */
- function tha_html_before() {
-	 do_action( 'tha_html_before' );
- }
+function tha_html_before() {
+	do_action( 'tha_html_before' );
+}
 /**
  * HTML <body> hooks
  * $tha_supports[] = 'body';
  */
- function tha_body_top() {
-	 do_action( 'tha_body_top' );
- }
+function tha_body_top() {
+	do_action( 'tha_body_top' );
+}
 
- function tha_body_bottom() {
-	 do_action( 'tha_body_bottom' );
- }
+function tha_body_bottom() {
+	if ( current_theme_supports( 'tha_hooks', 'body' ) && ! did_action( 'tha_body_bottom' ) )
+		do_action( 'tha_body_bottom' );
+}
+add_action( 'wp_footer', 'tha_body_bottom', 1 );
  
 /**
 * HTML <head> hooks
@@ -126,8 +128,10 @@ function tha_head_top() {
 }
 
 function tha_head_bottom() {
-	do_action( 'tha_head_bottom' );
+	if ( current_theme_supports( 'tha_hooks', 'body' ) && ! did_action( 'tha_head_bottom' ) )
+		do_action( 'tha_head_bottom' );
 }
+add_action( 'wp_head', 'tha_head_bottom', 1 );
 
 /**
 * Semantic <header> hooks


### PR DESCRIPTION
Makes placement of `tha_footer_bottom` and `tha_head_bottom` optional,
falling back to @obenland idea of hooking into the corresponding wp
standard hooks. Priority of `tha_body_bottom` moved higher then default
`wp_footer`. Also, a few whitespace cleanups.
