### PR TITLE
hook hooks into wp hooks

### DIFF
--- a/tha-theme-hooks.php
+++ b/tha-theme-hooks.php
@@ -112,9 +112,11 @@ add_filter( 'current_theme_supports-tha_hooks', 'tha_current_theme_supports', 10
 	 do_action( 'tha_body_top' );
  }
 
- function tha_body_bottom() {
-	 do_action( 'tha_body_bottom' );
- }
+function tha_body_bottom() {
+	if ( current_theme_supports( 'tha_hooks', 'body' ) && ! did_action( 'tha_body_bottom' ) )
+		do_action( 'tha_body_bottom' );
+}
+add_action( 'wp_footer', 'tha_body_bottom', 1 );
  
 /**
 * HTML <head> hooks
@@ -126,8 +128,10 @@ function tha_head_top() {
 }
 
 function tha_head_bottom() {
-	do_action( 'tha_head_bottom' );
+	if ( current_theme_supports( 'tha_hooks', 'body' ) && ! did_action( 'tha_head_bottom' ) )
+		do_action( 'tha_head_bottom' );
 }
+add_action( 'wp_head', 'tha_head_bottom', 1 );
 
 /**
 * Semantic <header> hooks


### PR DESCRIPTION
Hooks `tha_head_bottom` and `tha_body_bottom` to `wp_head` and `wp_footer` respectively, but won't run twice and won't run if the theme doesn't declare support for it. Makes adding the template tag optional.
