### PR TITLE
Added Decode theme to In-Progress list

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Working on it!
 ## THA-Compatible Themes ##
 * **In-Progress**
 	* [Elbee Elgee](http://literalbarrage.org/blog/code/elbee-elgee) by Doug Stewart ([bitbucket](https://bitbucket.org/zamoose/elbee-elgee))
+	* [Decode](http://scotthsmith.com/projects/decode/) by Scott Smith ([github](https://github.com/ScottSmith95/Decode))
 * **Full Support**
 	* [The Bootstrap](http://wordpress.org/extend/themes/the-bootstrap) by Konstantin Obenland ([github](https://github.com/obenland/the-bootstrap))
 	* [wolf](https://github.com/bradp/wolf) by Brad Parbs ([github](https://github.com/bradp/wolf))


### PR DESCRIPTION
I've added support for all Theme Hook Alliance hooks into the latest in-dev version for my theme Decode. They will be included in Decode 2.9.1.
