### PR TITLE
Move Decode from "In Progress" to "Full Support"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Working on it!
 ## THA-Compatible Themes ##
 * **In-Progress**
 	* [Elbee Elgee](http://literalbarrage.org/blog/code/elbee-elgee) by Doug Stewart ([bitbucket](https://bitbucket.org/zamoose/elbee-elgee))
-	* [Decode](http://scotthsmith.com/projects/decode/) by Scott Smith ([github](https://github.com/ScottSmith95/Decode))
+
 * **Full Support**
 	* [The Bootstrap](http://wordpress.org/extend/themes/the-bootstrap) by Konstantin Obenland ([github](https://github.com/obenland/the-bootstrap))
 	* [wolf](https://github.com/bradp/wolf) by Brad Parbs ([github](https://github.com/bradp/wolf))
@@ -66,3 +66,4 @@ Working on it!
 	* [Opus Primus](http://wordpress.org/extend/themes/opus-primus) (via a Stanza) by Cais ([github](https://github.com/Cais/opus-primus))
 	* [Oenology](http://www.chipbennett.net/themes/oenology/) by Chip Bennett ([github](https://github.com/chipbennett/oenology))
 	* [Museum Core](http://wordpress.org/extend/themes/museum-core/) by Chris Reynolds ([github](https://github.com/jazzsequence/museum-core))
+	* [Decode](http://scotthsmith.com/projects/decode/) by Scott Smith ([github](https://github.com/ScottSmith95/Decode))


### PR DESCRIPTION
The latest version of Decode has full THA hook support. Also, should this list be organized in a particular way, perhaps alphabetically?
